### PR TITLE
bugfix: allow omitting options object

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixes
+- bugfix: allow omitting options object ([#10](https://github.com/ungoldman/himawari-bg/issues/10))
+
 ## [1.0.0](https://github.com/ungoldman/himawari-bg/releases/tag/v1.0.0) - 2016-09-17
 
 [view diff](https://github.com/ungoldman/himawari-bg/compare/v1.0.0-beta...v1.0.0)

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var untildify = require('untildify')
 var bar = null
 
 module.exports = function (opts) {
+  opts = opts || {}
   var outfile = untildify(opts.outfile || `~/Pictures/himawari-images/${Date.now()}.jpg`)
 
   // create outfile directory just in case


### PR DESCRIPTION
Before `bg()` (as opposed to `bg({})`) threw an uncaught error, now it will not.