### PR TITLE
breaking: convert to async function

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,5 +15,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: lts/*
+    - name: Install external dependencies (imagemagick & friends)
+      run: sudo apt-get install -y imagemagick ghostscript graphicsmagick
     - run: npm i
     - run: npm test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js (Latest LTS)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: lts/*
-    - name: Install external dependencies (imagemagick & friends)
-      run: sudo apt-get install -y imagemagick ghostscript graphicsmagick
+    - run: brew install imagemagick graphicsmagick
     - run: npm i
     - run: npm test

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Usage: himawari-bg [options]
     --infrared, -i        Capture picture on the infrared spectrum. (default: false)
     --parallel, -p        Parallelize downloads for increased speeds (can be CPU intensive). (default: true)
     --screen, -s          Screen to set the wallpaper on (macOS only). Options: "all", "main", screen index. (default: "main")
-    --scale               Scaling method (macOS only). Options: "auto", "fill", "fit", "stretch", "center". (default: "auto")
+    --scale               Scaling method (macOS only). Options: "auto", "fill", "fit", "stretch", "center". (default: "fit")
     --version, -v         Show version information.
     --help, -h            Show help.
 ```
@@ -78,9 +78,9 @@ npm install himawari-bg
 Here is an example of how it works in node:
 
 ```js
-var bg = require('himawari-bg')
+const himawariBG = require('himawari-bg')
 
-bg({
+himawariBG({
   /**
    * The location to save the resulting image.
    * Default: `~/Pictures/himawari-images/${Date.now()}.jpg`
@@ -109,8 +109,40 @@ bg({
    * Default: false
    * @type {Boolean}
    */
-  infrared: false
+  infrared: false,
+
+  /**
+   * Screen to set the wallpaper on (macOS only)
+   * Options: 'all', 'main', screen index
+   * Default: 'main'
+   * @type {String|Number}
+   */
+  screen: 'main',
+
+  /**
+   * Scaling method (macOS only)
+   * Options: 'auto', 'fill', 'fit', 'stretch', 'center'
+   * Default: 'fit'
+   * @type {String|Number}
+   */
+  scale: 'fit'
 })
+```
+
+All config settings are optional and have default values.
+
+`himawariBG` returns a promise, so it can be used in an async workflow if needed.
+
+```js
+const himawariBG = require('himawari-bg')
+
+async function () {
+  try {
+    await himawariBG()
+  } catch (err) {
+    console.log(err)
+  }
+}
 ```
 
 ## Acknowledgements
@@ -134,15 +166,14 @@ Here are some useful links if you're interested in learning more about the Himaw
 
 ### Related Projects
 
-- [hi8](https://github.com/ungoldman/hi8) (menubar app version)
+- [@ungoldman/himawari](https://github.com/ungoldman/himawari)
+- [himawari-urls](https://github.com/ungoldman/himawari-urls)
+- [himawari-history](https://github.com/ungoldman/himawari-history)
 - [Glittering Blue](http://glittering.blue)
 - [celoyd/hi8](https://github.com/celoyd/hi8)
 - [Himawari 8 animation tutorial](https://gist.github.com/celoyd/b92d0de6fae1f18791ef)
 - [deband python script](https://gist.github.com/celoyd/a4dd9202fe5c7978b114)
 - [makeaday bash script](https://gist.github.com/celoyd/c2293929ab3fe97ea597)
-- [himawari.js](https://github.com/jakiestfu/himawari.js)
-- [himawari-urls](https://github.com/ungoldman/himawari-urls)
-- [himawari-history](https://github.com/ungoldman/himawari-history)
 
 ## Contributing
 

--- a/cli.js
+++ b/cli.js
@@ -46,7 +46,7 @@ const allowedOptions = [
   {
     name: 'scale',
     help: 'Scaling method (macOS only). Options: "auto", "fill", "fit", "stretch", "center".',
-    default: 'auto'
+    default: 'fit'
   },
   {
     name: 'version',

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "serve": "^13.0.2",
     "sitedown": "^5.0.1",
     "snazzy": "^9.0.0",
-    "standard": "^16.0.4"
+    "standard": "^16.0.4",
+    "tap-arc": "^0.3.4",
+    "tape": "^5.5.3"
   },
   "engines": {
     "node": ">=12"
@@ -47,6 +49,7 @@
   },
   "scripts": {
     "gh-pages": "npm run site && gh-pages -d site",
+    "pretest": "standard | snazzy",
     "serve:site": "serve site",
     "serve:watch": "npm run site:html -- -w",
     "site": "run-s site:*",
@@ -54,6 +57,6 @@
     "site:html": "sitedown -b site -l docs/layout.html",
     "site:img": "cp screenshot.jpg site/",
     "start": "npm-run-all site --parallel serve:*",
-    "test": "standard | snazzy"
+    "test": "tape test.js | tap-arc"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,29 @@
+const fs = require('fs')
+const path = require('path')
+const test = require('tape')
+const bg = require('./')
+const wallpaper = require('wallpaper')
+
+let originalImagePath
+
+test('main', async t => {
+  originalImagePath = await wallpaper.get()
+
+  await bg({ outfile: './test.jpg' })
+
+  await sleep(250) // let system catch up
+  const newPape = await wallpaper.get()
+  const testJpg = path.resolve('./test.jpg')
+  t.equal(newPape, testJpg)
+})
+
+test.onFinish(async () => {
+  await sleep(250)
+  await wallpaper.set(originalImagePath)
+  fs.unlinkSync('./test.jpg')
+})
+
+// shh
+function sleep (ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}


### PR DESCRIPTION
Now returns a promise.

Not _technically_ breaking as the interface remains the same for any old users in the wild.

However, this may mean a change in minimum node version for extremely old module consumers, so to be on the safe side I'll release this as a new a major version (along with the engines change in f0fc7a4e737cfcf6073db3df75ad71b073e3434b).

Honestly the main reason I bothered with this is for the sake of adding an actual unit test (which this PR also includes).

Approach to testing a wallpaper change was lifted from [`sindresorhus/wallpaper/test.js`](https://github.com/sindresorhus/wallpaper/blob/3b5cd8c279ffaccdffab379264c7dc7668825141/test.js).

Opening a PR for visibility. Will merge when (if) tests pass.